### PR TITLE
rework directory to be relative to file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+This release reworks the `draw.directory` setting to behave like a more standard filepath. Specifically, it's now relative to the current file (unless the path is absolute).
+
+To use the previous default behavior of inlining the svg content, set it to `null`. 
+
+To make the path relative to workspace root, use the `workspaceFolder` variable (e.g., `${workspaceFolder}/assets`).
+
+### Added
+
+- allow using the `${workspaceFolder}` variable in the `draw.directory` setting
+
 ### Changed
 
+- **BREAKING**: `draw.directory` is now relative to the current file if an absolute path is not given
+- **BREAKING**: to save files inline, `draw.directory` now must be `null` instead of an empty string
 - rename main command title from  `Edit Current Line` to `Edit Drawing` for clarity
 
 ## [0.1.21] - 2023-02-04

--- a/README.md
+++ b/README.md
@@ -39,10 +39,19 @@ Consider binding the main command (perhaps to a stylus, if available). For examp
 
 The following settings are available (prefixed with `draw`).
 
-| setting   | description                                                           | default |
-| --------- | --------------------------------------------------------------------- | ------- |
-| directory | if set, save files to this directory (relative to the workspace root) | `""`    |
-| buttons   | add [custom buttons](#custom-buttons) to the toolbar                  | `[]`    |
+| setting     | description                                          | default | example                     |
+| ----------- | ---------------------------------------------------- | ------- | --------------------------- |
+| `directory` | where to save files                                  | `""`    | `${workSpaceFolder}/assets` |
+| `buttons`   | add [custom buttons](#custom-buttons) to the toolbar | `[]`    | _see below_                 |
+
+### directory
+
+To save contents inline, set `draw.directory` to `null`.
+
+The following [variables](https://code.visualstudio.com/docs/editor/variables-reference) are currently supported:
+
+  - `workspaceFolder`
+
 
 ### custom buttons
 

--- a/package.json
+++ b/package.json
@@ -118,9 +118,9 @@
 					}
 				},
 				"draw.directory": {
-					"type": "string",
+					"type": ["string", "null"],
 					"default": "",
-					"description": "Save to directory (write inline if blank)"
+					"description": "Save to directory (write inline if null)"
 				}
 			}
 		}

--- a/src/draw.ts
+++ b/src/draw.ts
@@ -186,7 +186,12 @@ export class Draw {
             this.target = target;
             this.setState();
 
-            if (Draw.settings.directory) {
+            if (target.text.startsWith("<svg")) {
+                // text is probably an svg element
+                if (this.target.editor && (this.check[0] !== this.check[1]) && (target.text === this.check[0])) {
+                    if (push) Draw.panel?.webview.postMessage({ command: 'currentLine', content: target.text });
+                }
+            } else {
                 const link = langs.readLink(this.target.editor?.document.languageId || "markdown", target.text);
                 const paths = this.target.editor?.document.uri.path.split("/");
                 if (link && paths) {
@@ -199,15 +204,7 @@ export class Draw {
                         if (push) Draw.panel?.webview.postMessage({ command: 'currentLine', content: target.text });
                     });
                 }
-            } else {
-                // text is probably an svg element
-                if (target.text.startsWith("<svg")) {
 
-                    if (this.target.editor && (this.check[0] !== this.check[1]) && (target.text === this.check[0])) {
-                        if (push) Draw.panel?.webview.postMessage({ command: 'currentLine', content: target.text });
-                    }
-
-                }
             }
         }, 100);
     }
@@ -226,7 +223,7 @@ export class Draw {
         }
 
         // if a directory is set, and current line is not latex, replace the text with a link
-        if (Draw.settings.directory && Draw.settings.directory !== "" && !text.startsWith("$$")) {
+        if (Draw.settings.directory !== null && !text.startsWith("$$")) {
             text = langs.createLink(this.target.editor, text);
         }
 


### PR DESCRIPTION
These changes make the `directory` setting relative to the current file by default. See changelog entry for details.

I haven't tested this on Windows but it _should_ work as we're using the `Uri` type which, e.g., abstracts the directory separators (and matches existing logic so it shouldn't break anything new, at least).

Partially addresses #2.