### PR TITLE
Fix additional folder bug under windows

### DIFF
--- a/src/langs.ts
+++ b/src/langs.ts
@@ -22,7 +22,9 @@ export function createLink(editor: vscode.TextEditor, text: string): string {
     // if not an absolute path, prepend current directory
     if (!directory.startsWith("/")) {
         // get path to current file
-        const fsPath = editor.document.uri.fsPath;
+        let fsPath = editor.document.uri.fsPath;
+        // To ensure next line works properly (windows problem)
+        if (fsPath.includes("\\")) fsPath = editor.document.uri.path;
         // get directory of said file
         const fileDirname = fsPath.slice(0, fsPath.lastIndexOf("/"));
         // prepend directory to setting


### PR DESCRIPTION
When using windows and working in a file called for example `test.md`, the drawing will then be saved under `./test.m/hash.svg`

This is due to ` const fsPath = editor.document.uri.fsPath;` returning a path with backslashes (\) in windows, leading to `fsPath.slice(0, fsPath.lastIndexOf("/"));` cutting off only the last letter of the document.

My simple solution would be to add `if (fsPath.includes("\\")) fsPath = editor.document.uri.path;` to get a path with slashes (/) under windows.